### PR TITLE
Feat/category locking

### DIFF
--- a/commands/category/add.ts
+++ b/commands/category/add.ts
@@ -54,7 +54,7 @@ export class AddCategoryCommand extends SlashCommand {
     const category = await GET_CATEGORY_BY_ID(Number(categoryId));
 
     // To edit our button message with the updated list of react roles.
-    const categorilessRoles = (
+    const rolesWithoutCategories = (
       (await GET_REACT_ROLES_NOT_IN_CATEGORIES(interaction.guildId)) ?? []
     ).filter((r) => r.roleId !== reactRole?.roleId);
 
@@ -128,7 +128,7 @@ export class AddCategoryCommand extends SlashCommand {
     }
 
     const roleButtons = await this.buildReactRoleButtons(
-      categorilessRoles,
+      rolesWithoutCategories,
       Number(categoryId)
     );
 
@@ -158,6 +158,7 @@ export class AddCategoryCommand extends SlashCommand {
         `Failed to update roles[${reactRoleId}] categoryId[${categoryId}]\n${e}`,
         interaction.guildId
       );
+
       interaction
         .update({
           content: `Hey! I had an issue adding \`${reactRole.name}\` to the category \`${category.name}\`. Please wait a second and try again.`,
@@ -169,14 +170,6 @@ export class AddCategoryCommand extends SlashCommand {
           )
         );
     }
-
-    /**
-     * Grab role from db
-     * Grab category from db
-     * Check that the role has no category set.
-     * Update role and category to share relationship
-     *
-     */
   };
 
   /**

--- a/commands/category/edit.ts
+++ b/commands/category/edit.ts
@@ -37,6 +37,14 @@ export class EditCategoryCommand extends SlashCommand {
       'mutually-exclusive',
       'Change if roles in this category should be mutually exclusive.'
     );
+    this.addBoolOption(
+      'remove-required-role',
+      'Remove all required roles for the category.'
+    );
+    this.addRoleOption(
+      'new-required-role',
+      'Change what the required roles are for the category.'
+    );
   }
 
   execute = async (interaction: ChatInputCommandInteraction) => {
@@ -54,7 +62,20 @@ export class EditCategoryCommand extends SlashCommand {
     const mutuallyExclusive =
       interaction.options.getBoolean('mutually-exclusive');
 
-    if (!newName && !newDesc && mutuallyExclusive === null) {
+    const removeRequiredRole = interaction.options.getBoolean(
+      'remove-required-role'
+    );
+
+    const newRequiredRoleId =
+      interaction.options.getRole('new-required-role')?.id ?? undefined;
+
+    if (
+      !newName &&
+      !newDesc &&
+      !newRequiredRoleId &&
+      removeRequiredRole === null &&
+      mutuallyExclusive === null
+    ) {
       this.log.info(
         `User didn't change anything about the category`,
         interaction.guildId
@@ -93,10 +114,13 @@ export class EditCategoryCommand extends SlashCommand {
       );
     }
 
+    const requiredRoleId = newRequiredRoleId ?? category.requiredRoleId;
+
     const updatedCategory: Partial<ICategory> = {
       name: newName ?? category.name,
       description: newDesc ?? category.description,
       mutuallyExclusive: mutuallyExclusive ?? category.mutuallyExclusive,
+      requiredRoleId: removeRequiredRole ? null : requiredRoleId,
     };
 
     EDIT_CATEGORY_BY_ID(category.id, updatedCategory)

--- a/commands/commandHandler.ts
+++ b/commands/commandHandler.ts
@@ -66,11 +66,13 @@ async function deleteSlashCommands(route: `/${string}`) {
   const log = new LogService('DeleteSlashCommands');
 
   try {
-    rest.get(route).then((data) => {
+    return rest.get(route).then((data) => {
       const promises = [];
       for (const command of data as { id: string }[]) {
         promises.push(rest.delete(`${route}/${command.id}`));
       }
+
+      log.info('Deleting old commands...');
 
       return Promise.all(promises);
     });

--- a/commands/commandHandler.ts
+++ b/commands/commandHandler.ts
@@ -34,7 +34,9 @@ export const buildSlashCommands = async (
       ? Routes.applicationGuildCommands(CLIENT_ID, SERVER_ID)
       : Routes.applicationCommands(CLIENT_ID);
 
-    //await deleteSlashCommands(route);
+    log.info(`Using route '${route}'`);
+
+    await deleteSlashCommands(route);
     await generateSlashCommands(route, commandsJson);
   }
 };

--- a/commands/general/join.ts
+++ b/commands/general/join.ts
@@ -18,6 +18,7 @@ import {
 } from '../../src/database/queries/joinRole.query';
 import { EmbedService } from '../../src/services/embedService';
 import { Category } from '../../utilities/types/commands';
+import { RolePing } from '../../utilities/utilPings';
 import {
   handleInteractionReply,
   isValidRolePosition,
@@ -104,7 +105,9 @@ export class AutoJoinCommand extends SlashCommand {
 
         handleInteractionReply(this.log, interaction, {
           ephemeral: true,
-          content: `:tada: I successfully added <@&${role.id}> to the auto-join list.`,
+          content: `:tada: I successfully added ${RolePing(
+            role.id
+          )} to the auto-join list.`,
         });
       } catch (e) {
         handleInteractionReply(this.log, interaction, {
@@ -202,7 +205,9 @@ export class AutoJoinCommand extends SlashCommand {
         const embed = new EmbedBuilder()
           .setTitle('Reaction Roles Setup')
           .setDescription(
-            `The role <@&${role.id}> is above me in the role list which you can find in \`Server settings > Roles\`.
+            `The role ${RolePing(
+              role.id
+            )} is above me in the role list which you can find in \`Server settings > Roles\`.
             \nPlease make sure that my role \`RoleBot\` is higher than the roles you give me in your servers role hierarchy.`
           );
 

--- a/commands/react/channel.ts
+++ b/commands/react/channel.ts
@@ -12,6 +12,7 @@ import { Category } from '../../utilities/types/commands';
 import { PermissionMappings, SlashCommand } from '../slashCommand';
 import { GET_GUILD_CATEGORIES } from '../../src/database/queries/category.query';
 import { GET_REACT_ROLES_BY_CATEGORY_ID } from '../../src/database/queries/reactRole.query';
+import { ChannelPing } from '../../utilities/utilPings';
 
 export class ReactChannelCommand extends SlashCommand {
   constructor(client: RoleBot) {
@@ -132,7 +133,9 @@ export class ReactChannelCommand extends SlashCommand {
       .join(' ');
 
     const permissionError =
-      `Hey! I don't have the right permissions in <#${channel.id}> to correctly setup the react role embeds. I need ${permissions} to work as intended.` +
+      `Hey! I don't have the right permissions in ${ChannelPing(
+        channel.id
+      )} to correctly setup the react role embeds. I need ${permissions} to work as intended.` +
       'Why do I need these permissions in this channel?\n' +
       codeBlock(`
       - To be able to react I have to be able to see the message so I need the history for the channel.

--- a/commands/react/channel.ts
+++ b/commands/react/channel.ts
@@ -1,4 +1,3 @@
-import { codeBlock } from '@discordjs/builders';
 import {
   ChannelType,
   ChatInputCommandInteraction,
@@ -9,10 +8,10 @@ import RoleBot from '../../src/bot';
 import { EmbedService } from '../../src/services/embedService';
 import { reactToMessage } from '../../utilities/utils';
 import { Category } from '../../utilities/types/commands';
-import { PermissionMappings, SlashCommand } from '../slashCommand';
+import { SlashCommand } from '../slashCommand';
 import { GET_GUILD_CATEGORIES } from '../../src/database/queries/category.query';
 import { GET_REACT_ROLES_BY_CATEGORY_ID } from '../../src/database/queries/reactRole.query';
-import { ChannelPing } from '../../utilities/utilPings';
+import { requiredPermissions } from '../../utilities/utilErrorMessages';
 
 export class ReactChannelCommand extends SlashCommand {
   constructor(client: RoleBot) {
@@ -122,29 +121,6 @@ export class ReactChannelCommand extends SlashCommand {
         );
     }
 
-    const permissions = [
-      PermissionsBitField.Flags.ReadMessageHistory,
-      PermissionsBitField.Flags.AddReactions,
-      PermissionsBitField.Flags.SendMessages,
-      PermissionsBitField.Flags.ManageMessages,
-      PermissionsBitField.Flags.ManageRoles,
-    ]
-      .map((p) => `\`${PermissionMappings.get(p)}\``)
-      .join(' ');
-
-    const permissionError =
-      `Hey! I don't have the right permissions in ${ChannelPing(
-        channel.id
-      )} to correctly setup the react role embeds. I need ${permissions} to work as intended.` +
-      'Why do I need these permissions in this channel?\n' +
-      codeBlock(`
-      - To be able to react I have to be able to see the message so I need the history for the channel.
-      - Have to be able to react, it is a react role bot.
-      - Have to be able to send embeds.
-      - To update the embeds react role list.
-      - To update users roles.
-      `);
-
     /* There might be a better solution to this. Potentially reply first, then update the interaction later. Discord interactions feel so incredibly inconsistent though. So for now force users to WAIT the whole 3 seconds so that Discord doesn't cry. */
     await new Promise((res) => {
       setTimeout(
@@ -157,6 +133,8 @@ export class ReactChannelCommand extends SlashCommand {
     const textChannel = await interaction.guild?.channels.fetch(channel.id);
     if (textChannel?.type !== ChannelType.GuildText) return;
 
+    const permissionError = requiredPermissions(channel.id);
+
     for (const category of categories) {
       const categoryRoles = await GET_REACT_ROLES_BY_CATEGORY_ID(category.id);
       if (!categoryRoles.length) continue;
@@ -168,7 +146,7 @@ export class ReactChannelCommand extends SlashCommand {
           embeds: [embed],
         });
 
-        reactToMessage(
+        const isSuccessfulReacting = await reactToMessage(
           reactEmbedMessage,
           interaction.guildId,
           categoryRoles,
@@ -177,21 +155,22 @@ export class ReactChannelCommand extends SlashCommand {
           false,
           this.log
         );
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (e: any) {
-        this.log.error(`Failed to send embeds.\n${e}`, interaction.guildId);
 
-        /**
-         * Somehow the type DiscordAPIError DOES NOT include the httpStatus code despite the returned error here having it.
-         * They also only set their "status" property as undefined. Lol?
-         */
-        if (e?.httpStatus === 403) {
+        if (!isSuccessfulReacting) {
+          reactEmbedMessage
+            .delete()
+            .catch(() =>
+              this.log.info(
+                `Failed to delete embed message after failing reaction.`
+              )
+            );
+
           return interaction.editReply(permissionError);
         }
+      } catch (e) {
+        this.log.error(`Failed to send embeds.\n${e}`, interaction.guildId);
 
-        return interaction.editReply(
-          `Hey! I encounted an error. Report this to the support server. \`${e}\``
-        );
+        return interaction.editReply(permissionError);
       }
 
       await new Promise((res) => {
@@ -201,7 +180,7 @@ export class ReactChannelCommand extends SlashCommand {
 
     interaction
       .editReply({
-        content: 'Hey! I sent those embeds and am currently reacting to them.',
+        content: 'Hey! I successfully sent the embeds and reacted to them!',
       })
       .catch((e) =>
         this.log.error(

--- a/commands/react/create.ts
+++ b/commands/react/create.ts
@@ -22,6 +22,7 @@ import {
   GET_REACT_ROLE_BY_EMOJI,
   GET_REACT_ROLE_BY_ROLE_ID,
 } from '../../src/database/queries/reactRole.query';
+import { RolePing } from '../../utilities/utilPings';
 
 export class ReactRoleCommand extends SlashCommand {
   constructor(client: RoleBot) {
@@ -77,7 +78,9 @@ export class ReactRoleCommand extends SlashCommand {
       const embed = new EmbedBuilder()
         .setTitle('Reaction Roles Setup')
         .setDescription(
-          `The role <@&${role.id}> is above me in the role list which you can find in \`Server settings > Roles\`.\nPlease make sure that my role that is listed above the roles you want to assign.`
+          `The role ${RolePing(
+            role.id
+          )} is above me in the role list which you can find in \`Server settings > Roles\`.\nPlease make sure that my role that is listed above the roles you want to assign.`
         );
 
       const button = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -153,7 +156,9 @@ export class ReactRoleCommand extends SlashCommand {
 
       return handleInteractionReply(this.log, interaction, {
         ephemeral: true,
-        content: `The react role (${emojiMention} - <@&${reactRole.roleId}>) already has this emoji assigned to it.`,
+        content: `The react role (${emojiMention} - ${RolePing(
+          reactRole.roleId
+        )}) already has this emoji assigned to it.`,
       });
     }
 
@@ -166,7 +171,9 @@ export class ReactRoleCommand extends SlashCommand {
       const emojiMention = reactRole?.emojiTag ?? reactRole?.emojiId;
       return handleInteractionReply(this.log, interaction, {
         ephemeral: true,
-        content: `There's a react role already using the role \`${reactRole.name}\` (${emojiMention} - <@&${reactRole.roleId}>).`,
+        content: `There's a react role already using the role \`${
+          reactRole.name
+        }\` (${emojiMention} - ${RolePing(reactRole.roleId)}).`,
       });
     }
 
@@ -193,7 +200,9 @@ export class ReactRoleCommand extends SlashCommand {
 
         handleInteractionReply(this.log, interaction, {
           ephemeral: true,
-          content: `:tada: Successfully created the react role (${emojiMention} - <@&${role.id}>) :tada: \n**Make sure to add your newly created react role to a category with \`/category-add\`!**`,
+          content: `:tada: Successfully created the react role (${emojiMention} - ${RolePing(
+            role.id
+          )}) :tada: \n**Make sure to add your newly created react role to a category with \`/category-add\`!**`,
         });
       })
       .catch((e) => {

--- a/commands/react/remove.ts
+++ b/commands/react/remove.ts
@@ -12,6 +12,7 @@ import {
   DELETE_REACT_ROLE_BY_ROLE_ID,
   GET_REACT_ROLE_BY_ROLE_ID,
 } from '../../src/database/queries/reactRole.query';
+import { RolePing } from '../../utilities/utilPings';
 
 export class ReactDeleteCommand extends SlashCommand {
   constructor(client: RoleBot) {
@@ -67,7 +68,9 @@ export class ReactDeleteCommand extends SlashCommand {
 
       handleInteractionReply(this.log, interaction, {
         ephemeral: true,
-        content: `I successfully removed the react role (${emojiMention} - <@&${role.id}>)! You can add it back at any time if you wish.\n\nI'm gonna do some cleanup now and update any react role embed...`,
+        content: `I successfully removed the react role (${emojiMention} - ${RolePing(
+          role.id
+        )})! You can add it back at any time if you wish.\n\nI'm gonna do some cleanup now and update any react role embed...`,
       });
 
       // Only update react message if there's a category associated with it.

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,5 +1,5 @@
 import * as config from './vars';
-import commandHandler from '../commands/commandHandler';
+import { buildSlashCommands } from '../commands/commandHandler';
 import { guildUpdate } from '../events/guildUpdate';
 import { SlashCommand } from '../commands/slashCommand';
 import { InteractionHandler } from './services/interactionHandler';
@@ -149,6 +149,6 @@ export default class RoleBot extends Discord.Client {
     this.log.info('Bot connected.');
 
     // Slash commands can only load once the bot is connected?
-    commandHandler(this);
+    buildSlashCommands(this, false, true);
   };
 }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -149,6 +149,6 @@ export default class RoleBot extends Discord.Client {
     this.log.info('Bot connected.');
 
     // Slash commands can only load once the bot is connected?
-    buildSlashCommands(this, true, config.CLIENT_ID === '493668628361904139');
+    buildSlashCommands(this, true, config.CLIENT_ID !== '493668628361904139');
   };
 }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -149,6 +149,6 @@ export default class RoleBot extends Discord.Client {
     this.log.info('Bot connected.');
 
     // Slash commands can only load once the bot is connected?
-    buildSlashCommands(this, false, true);
+    buildSlashCommands(this, true, config.CLIENT_ID === '493668628361904139');
   };
 }

--- a/src/database/entities/category.entity.ts
+++ b/src/database/entities/category.entity.ts
@@ -3,8 +3,9 @@ import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 export interface ICategory {
   guildId: string;
   name: string;
-  description: string;
-  mutuallyExclusive: boolean;
+  description?: string;
+  mutuallyExclusive?: boolean;
+  requiredRoleId: string | null;
 }
 
 @Entity()
@@ -19,8 +20,11 @@ export class Category extends BaseEntity {
   name!: string;
 
   @Column()
-  description?: string;
+  description!: string;
 
   @Column()
-  mutuallyExclusive?: boolean;
+  mutuallyExclusive!: boolean;
+
+  @Column({ type: 'text', nullable: true })
+  requiredRoleId!: string | null;
 }

--- a/src/database/queries/category.query.ts
+++ b/src/database/queries/category.query.ts
@@ -13,20 +13,16 @@ export const GET_ROLES_BY_CATEGORY_ID = async (categoryId: number) => {
   });
 };
 
-export const CREATE_GUILD_CATEGORY = async (
-  guildId: string,
-  name: string,
-  description: string | undefined,
-  mutuallyExclusive: boolean | undefined
-) => {
-  const category = new Category();
+export const CREATE_GUILD_CATEGORY = async (category: ICategory) => {
+  const newCategory = new Category();
 
-  category.guildId = guildId;
-  category.name = name;
-  category.description = description ?? '';
-  category.mutuallyExclusive = mutuallyExclusive ?? false;
+  newCategory.guildId = category.guildId;
+  newCategory.name = category.name;
+  newCategory.description = category.description ?? '';
+  newCategory.mutuallyExclusive = category.mutuallyExclusive ?? false;
+  newCategory.requiredRoleId = category.requiredRoleId;
 
-  return await category.save();
+  return await newCategory.save();
 };
 
 export const EDIT_CATEGORY_BY_ID = (

--- a/src/services/reactionHandler.ts
+++ b/src/services/reactionHandler.ts
@@ -80,6 +80,17 @@ export class ReactionHandler {
       );
     }
 
+    // If the category limits who can react and the user doesn't have said role ignore request.
+    if (
+      category.requiredRoleId &&
+      !member.roles.cache.has(category.requiredRoleId)
+    ) {
+      // Remove reaction as to not confuse the user that they succeeded.
+      return reaction
+        .remove()
+        .catch(() => this.log.debug(`Failed to remove reaction`));
+    }
+
     if (category.mutuallyExclusive) {
       return this.mutuallyExclusive(reactMessage, member, guild, type);
     }

--- a/src/services/reactionHandler.ts
+++ b/src/services/reactionHandler.ts
@@ -86,8 +86,8 @@ export class ReactionHandler {
       !member.roles.cache.has(category.requiredRoleId)
     ) {
       // Remove reaction as to not confuse the user that they succeeded.
-      return reaction
-        .remove()
+      return reaction.users
+        .remove(member)
         .catch(() => this.log.debug(`Failed to remove reaction`));
     }
 

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -12,6 +12,7 @@ export const TOKEN: string = process.env.TOKEN || '';
 export const DB_NAME = process.env.DB_NAME || 'rolebotBeta';
 export const POSTGRES_URL = `${process.env.POSTGRES_URL}${DB_NAME}` || '';
 export const SHARD_COUNT = Number(process.env.SHARD_COUNT) || 6;
+export const SERVER_ID = '567819334852804626';
 // Only sync when in dev
 export const SYNC_DB = Boolean(Number(process.env.SYNC_DB)) || false;
 export const WEBHOOK_ID = process.env.WEBHOOK_ID || '';

--- a/utilities/json/errors.json
+++ b/utilities/json/errors.json
@@ -1,0 +1,5 @@
+{
+  "required_permissions": " - READ_MESSAGE_HISTORY\n - ADD_REACTIONS\n - SEND_MESSAGES\n - MANAGE_MESSAGES\n - MANAGE_ROLES",
+  "permission_reasons": " - To be able to react I have to be able to see the message thus I need to see message history for the channel.\n - Have to be able to react, it is a react role bot.\n - Have to be able to send embeds\n - To update the embeds react role list.\n - To update user roles.",
+  "missing_permissions": "Hey! I don't have the right permissions in {{channel}} to correctly setup the react role embeds.\n\nI need these permissions to work as intended.\n{{permissions}}\nWhy do I need these permissions?\n{{permission_reasons}}"
+}

--- a/utilities/utilErrorMessages.ts
+++ b/utilities/utilErrorMessages.ts
@@ -1,0 +1,15 @@
+import errors from './json/errors.json';
+import { codeBlock } from 'discord.js';
+import { ChannelPing } from './utilPings';
+
+export const requiredPermissions = (channelId: string) => {
+  const resultString = errors['missing_permissions']
+    .replace(/{{channel}}/g, ChannelPing(channelId))
+    .replace(/{{permissions}}/g, codeBlock(errors['required_permissions']))
+    .replace(
+      /{{permission_reasons}}/g,
+      codeBlock(errors['permission_reasons'])
+    );
+
+  return resultString;
+};

--- a/utilities/utilPings.ts
+++ b/utilities/utilPings.ts
@@ -1,0 +1,3 @@
+export const ChannelPing = (channelId: string) => `<#${channelId}>`;
+export const UserPing = (userId: string) => `<@${userId}>`;
+export const RolePing = (roleId: string) => `<@&${roleId}>`;


### PR DESCRIPTION
Categories can now be locked behind a role requirement.

An example of how to use this is if you have a leveling bot, you can have categories locked behind levels.

![image](https://user-images.githubusercontent.com/14780600/194482475-95778829-7b90-4a69-9287-e1c7c263ed24.png)
