### PR TITLE
feat: react role cleanup command

### DIFF
--- a/commands/category/list.ts
+++ b/commands/category/list.ts
@@ -62,7 +62,7 @@ export class ListCategoryCommand extends SlashCommand {
 
     interaction
       .editReply(
-        `Hey! Let me build these embeds for you real quick and send them...`
+        `Hey! Let me build those embeds for you.\n\nIf you notice any react roles that have deleted roles run \`/react-clean\` to remove them.`
       )
       .catch((e) =>
         this.log.error(`Interaction failed.\n${e}`, interaction.guildId)

--- a/commands/category/update.ts
+++ b/commands/category/update.ts
@@ -127,7 +127,9 @@ export class UpdateCategoryCommand extends SlashCommand {
 
       return handleInteractionReply(this.log, interaction, {
         ephemeral: true,
-        content: `Hey! I see that message uses category \`${category.name}\` but it has no react roles in it.`,
+        content:
+          `Hey! I see that message uses category \`${category.name}\` but it has no react roles in it.\n` +
+          `Add some react roles to the category with \`/category-add\` and then try update again. Otherwise just delete it!`,
       });
     }
 
@@ -140,7 +142,9 @@ export class UpdateCategoryCommand extends SlashCommand {
       // Clear all reactions to remove and old incorrect reactions.
       await message.reactions
         .removeAll()
-        .catch(() => this.log.info(`Failed to remove all reactions.`));
+        .catch(() =>
+          this.log.info(`Failed to remove all reactions.`, interaction.guildId)
+        );
 
       await message
         .edit({ embeds: [embed] })

--- a/commands/general/help.ts
+++ b/commands/general/help.ts
@@ -77,7 +77,7 @@ export class HelpCommand extends SlashCommand {
       .setTimestamp(new Date());
 
     embed.setDescription(
-      `Hey! I got a new look. **If you're unsure what to do check out \`/tutorial\`!!**\n
+      `Hey! **If you've never used me before make sure to check out \`/tutorial\`! It'll explain how RoleBot works.**\n
       **Want to host the bot yourself? Check out the [GitHub](https://github.com/Uhuh/RoleBot)**
       \nThanks for using me! I know setting up reaction roles can be scary so here's some helpful descriptions for each commands!${''}\nI've broken them up by category for your convenience.`
     );

--- a/commands/general/tutorial.ts
+++ b/commands/general/tutorial.ts
@@ -8,8 +8,11 @@ import {
 import { EmbedService } from '../../src/services/embedService';
 import { Category } from '../../utilities/types/commands';
 import { SlashCommand } from '../slashCommand';
+import tutorialJson from '../../utilities/json/tutorial.json';
 
 export class TutorialCommand extends SlashCommand {
+  readonly maxPage = tutorialJson['embeds'].length - 1;
+
   constructor() {
     super(
       'tutorial',
@@ -27,7 +30,7 @@ export class TutorialCommand extends SlashCommand {
         .setStyle(ButtonStyle.Secondary),
       new ButtonBuilder()
         .setCustomId(`${this.name}_${pageId + 1}`)
-        .setDisabled(pageId === 3)
+        .setDisabled(pageId === this.maxPage)
         .setLabel('Next')
         .setStyle(ButtonStyle.Primary)
     );

--- a/commands/react/clean.ts
+++ b/commands/react/clean.ts
@@ -1,0 +1,67 @@
+import { ChatInputCommandInteraction } from 'discord.js';
+import {
+  DELETE_REACT_ROLE_BY_ROLE_ID,
+  GET_REACT_ROLES_BY_GUILD,
+} from '../../src/database/queries/reactRole.query';
+import { Category } from '../../utilities/types/commands';
+import { SlashCommand } from '../slashCommand';
+
+export class ReactCleanCommand extends SlashCommand {
+  constructor() {
+    super(
+      'react-clean',
+      `If you delete a role RoleBot might miss it, this will remove '@deleted' roles.`,
+      Category.react
+    );
+  }
+
+  execute = async (interaction: ChatInputCommandInteraction) => {
+    if (!interaction.guildId) {
+      return this.log.error(`GuildID did not exist on interaction.`);
+    }
+
+    try {
+      await interaction
+        .deferReply({
+          ephemeral: true,
+        })
+        .catch((e) =>
+          this.log.error(
+            `Failed to defer interaction and the try/catch didn't catch it.\n${e}`,
+            interaction.guildId
+          )
+        );
+    } catch (e) {
+      return this.log.error(
+        `Failed to defer interaction.\n${e}`,
+        interaction.guildId
+      );
+    }
+
+    let numRemovedRoles = 0;
+
+    try {
+      const reactRoles = await GET_REACT_ROLES_BY_GUILD(interaction.guildId);
+      const nonCachedRoles = reactRoles.filter(
+        (r) => !interaction.guild?.roles.cache.has(r.roleId)
+      );
+
+      for (const role of nonCachedRoles) {
+        const fetchedRole = await interaction.guild?.roles.fetch(role.roleId);
+        if (!fetchedRole) {
+          this.log.debug(`Purging old react role[${role.roleId}]`);
+          await DELETE_REACT_ROLE_BY_ROLE_ID(role.roleId);
+          numRemovedRoles++;
+        }
+      }
+    } catch (e) {
+      return this.log.error(`Failed to filter old.\n${e}`, interaction.guildId);
+    }
+
+    const reply = numRemovedRoles
+      ? `Removed ${numRemovedRoles} dead react roles.`
+      : 'There are no dead react roles.';
+
+    interaction.editReply(reply);
+  };
+}

--- a/commands/react/index.ts
+++ b/commands/react/index.ts
@@ -4,3 +4,4 @@ export { ReactListCommand } from './list';
 export { ReactMessageCommand } from './message';
 export { ReactDeleteCommand } from './remove';
 export { ReactNukeCommand } from './nuke';
+export { ReactCleanCommand } from './clean';

--- a/commands/react/list.ts
+++ b/commands/react/list.ts
@@ -57,7 +57,7 @@ export class ReactListCommand extends SlashCommand {
 
     interaction
       .editReply({
-        content: `Hey! Here's your react roles.`,
+        content: `Hey! Here's your react roles. If you notice any \`@deleted\` roles run \`/react-clean\` to remove them.`,
         embeds: [embed],
       })
       .catch((e) =>

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,5 +1,5 @@
 import * as config from './vars';
-import { buildCommands } from '../commands/commandHandler';
+import { buildCommands, buildSlashCommands } from '../commands/commandHandler';
 import { guildUpdate } from '../events/guildUpdate';
 import { SlashCommand } from '../commands/slashCommand';
 import { InteractionHandler } from './services/interactionHandler';
@@ -144,5 +144,7 @@ export default class RoleBot extends Discord.Client {
     this.log.info(`Connecting to Discord with bot token.`);
     await this.login(this.config.TOKEN);
     this.log.info('Bot connected.');
+
+    buildSlashCommands(true, config.CLIENT_ID !== '493668628361904139');
   };
 }

--- a/src/services/embedService.ts
+++ b/src/services/embedService.ts
@@ -32,7 +32,6 @@ export class EmbedService {
   /**
    * Generate an embed that contains all the emojis to roles in a category.
    * @param category Category to parse roles from.
-   * @param client RoleBot to find emojis.
    * @returns built embed.
    */
   public static categoryReactRoleEmbed = async (category: Category) => {
@@ -145,7 +144,8 @@ export class EmbedService {
     embed
       .setColor(COLOR.DEFAULT)
       .setTitle(embedJson.title)
-      .setDescription(embedJson.description);
+      .setDescription(embedJson.description.join('\n'))
+      .setImage(embedJson.image);
 
     return embed;
   };

--- a/utilities/json/commands.json
+++ b/utilities/json/commands.json
@@ -49,6 +49,10 @@
       "description": "Send all categories with react roles to the selected channel."
     },
     {
+      "name": "react-clean",
+      "description": "If you delete a role RoleBot might miss it, this will remove '@deleted' roles."
+    },
+    {
       "name": "react-create",
       "description": "Create a new react role. Give the command a role and an emoji. It really is that simple."
     },

--- a/utilities/json/tutorial.json
+++ b/utilities/json/tutorial.json
@@ -2,31 +2,65 @@
   "embeds": [
     {
       "title": "Where to start. | Page 1",
-      "description": "RoleBot's been reworked quite a bit! With this new :tada:cleanup:tada: RoleBot can help manage your react roles a lot easier now!\n\n**Firstly**, RoleBot used to have a thing called \"folders\". That's been renamed to \"category\". It just felt right, yknow?\n\n**Secondly**, RoleBot now forces you to use categories as a way to manage all of your react roles. It's easier to track things with a category.\n\n**To start off** let's create a category with the `/category-create` command. I'm going to make a **Colors** category and store color react roles in it later.",
-      "images": [
-        ""
-      ]
+      "description": [
+        "Welcome to RoleBot! To understand how RoleBot works we need to understand what a `category` and `react role` is and how they work together when we talk about RoleBot.\n",
+        "When we refer to a `category` we're describing how RoleBot groups together a bunch of react roles, **not** a Discord category. Categories can be configured to change up how users obtain roles. More on this later!\n",
+        "When we refer to a `react role` we're describing the relationship you make between an **emoji** and a **Discord role**. RoleBot uses this information to know what role to give a user when they react to a setup message.\n",
+        "**React roles** MUST be within a **category** in order for users to obtain any roles. RoleBot uses categories as a way to remember react roles and settings for each one."
+      ],
+      "image": "https://s3.us-east-2.amazonaws.com/rolebot.gg/assets/banners/banner.png"
     },
     {
-      "title": "Creating React Roles. | Page 2",
-      "description": "Creating react roles is easy! Simply do `/react-role` and pass in the role and emoji you want paired together.\n\nReact roles aren't very useful by themselves. They need to be placed into a `category`. Again these are also easy to make using the `/category-create` command. You can make react roles inside a category `mutually exclusive`. This means a user can only have one react role from that category at a time when reacting.",
-      "images": [
-        ""
-      ]
+      "title": "How to create a react role. | Page 2",
+      "description": [
+        "When creating a react role with RoleBot there's two things you need to keep in mind.\n",
+        "**You cannot have duplicate roles OR emojis**. This is vital since RoleBot uses the emoji reacted with to figure out which role a user should get.",
+        "Creating a react role is easy! Simply do `/react-role` then pass in the role and emoji you want paired together.\n",
+        "It's recommended that you create a few react roles before adding them to a category to save time.\n",
+        "**Warning:** Sometimes you may want to delete a role in your server, most times RoleBot will catch that and remove react roles that had that. If RoleBot misses that and you see `@deleted` in the react role list use the `/react-clean` command.\n",
+        "_(If you do decide to add a lot of react roles at the start, you'll be limited to 25 react roles until you start adding them to categories. This is a Discord limitation.)_"
+      ],
+      "image": "https://media.discordapp.net/attachments/935424318471548978/1028514952186704002/unknown.png"
     },
     {
-      "title": "Adding React Roles to Categories. | Page 3",
-      "description": "Now we're getting to the most important part, adding react roles to a category. Again it's fairly simple! Just use the `/category-add` command, this will give you a dropdown menu to select a category from.\nWhen you select your category RoleBot will then show you all categoriless react roles as buttons where you can then click on them to add them to the category! *Pretty simple huh?*",
-      "images": [
-        ""
-      ]
+      "title": "How to create a category. | Page 3",
+      "description": [
+        "Categories are how RoleBot group together react roles. Let's go over what each category setting does.\n",
+        "When creating a category we use the command `/category-create`. **By default you're only required to give the category a name and can leave the other options empty.**",
+        "* `category-desc` is the category description. This is text that will show above the react roles in the embed when displayed. Use it to briefly describe the purpose of the category or theme.",
+        "* `mutually-exclusive` is what dictates if a user can obtain all roles from a category or only one. If the value for this is true then a user may only get one role at a time from the category.",
+        "* `required-role` will only allow users with a specific role to react and obtain roles from the category."
+      ],
+      "image": "https://media.discordapp.net/attachments/935424318471548978/1028513235390955620/unknown.png"
     },
     {
-      "title": "Setting up the React Role messages. | Page 4",
-      "description": "So now that we created our React Roles, our Category, and added the React Roles into the Category. Let's actually have RoleBot monitor messages for reactions.\n\nThere are **two** different ways we can have RoleBot work for us. RoleBot can use its own messages in the `/react-channel` command, where it will create am embed for each category and list the react roles inside it and then react to it, thus watching all reactions on it, or.\n\nWe can have RoleBot monitor custom messages. Do you have a cutely formatted message you want to use instead of RoleBot's embeds? Use `/react-message` and give the command a message link. This will allow you to select which category RoleBot uses for that message. ",
-      "images": [
-        ""
-      ]
+      "title": "How to add react roles to a category. | Page 4",
+      "description": [
+        "Adding react roles is simple. We start by running the `/category-add` command.",
+        "RoleBot will prompt you to select which category you would like to add react roles to with a dropdown menu.\n",
+        "Once you select the category you want to add to, RoleBot will present to you the react roles you create in button form. Click each react role you want to add to the category.\n",
+        "**Each category can only hold a max of 20 react roles due to Discords message reaction limit.**"
+      ],
+      "image": "https://media.discordapp.net/attachments/935424318471548978/1028540253021159455/unknown.png"
+    },
+    {
+      "title": "How to give out roles. | Page 5",
+      "description": [
+        "Now that we created our React Roles, our Category, and added the React Roles into the Category. Let's actually have RoleBot monitor messages for reactions.\n",
+        "**There are _two_ different ways for RoleBot to listen for reactions.**",
+        "One, you can use `/react-channel` to select a channel that RoleBot will send all of its default embeds to and react to.",
+        "Two, you can use `/react-message` to select a specific message, usually one you wrote and select a single category for RoleBot to react with.\n"
+      ],
+      "image": "https://media.discordapp.net/attachments/935424318471548978/1028550952279609394/unknown.png"
+    },
+    {
+      "title": "The end. | Page 6",
+      "description": [
+        "And that's all folks! That's the basics for RoleBot.\n",
+        "There are a few things to pay attention to, most times RoleBot doesn't work as expected is due to RoleBot not having the correct permissions. So make sure to check those!\n",
+        "If you ever need help join the [support server!](https://discord.gg/9BYN266sC4)"
+      ],
+      "image": "https://s3.us-east-2.amazonaws.com/rolebot.gg/assets/banners/banner.png"
     }
   ]
 }


### PR DESCRIPTION
Sometimes users delete a role on the server and RoleBot can miss that event, thus failing to update the DB.
This creates an issue where users have "@deleted" roles in their list and can't delete it because the role no longer exist.

* New react-* command called clean that purges dead react roles in a server.