### PR TITLE
feat: react edit

### DIFF
--- a/commands/react/edit.ts
+++ b/commands/react/edit.ts
@@ -1,0 +1,81 @@
+import {
+  ChatInputCommandInteraction,
+  parseEmoji,
+  PermissionsBitField,
+} from 'discord.js';
+import {
+  UPDATE_REACT_ROLE_EMOJI_ID,
+  UPDATE_REACT_ROLE_EMOJI_TAG,
+} from '../../src/database/queries/reactRole.query';
+import { Category } from '../../utilities/types/commands';
+import { RolePing } from '../../utilities/utilPings';
+import { SlashCommand } from '../slashCommand';
+
+export class ReactEditCommand extends SlashCommand {
+  constructor() {
+    super(
+      'react-edit',
+      'Edit any existing react roles emoji!',
+      Category.react,
+      [PermissionsBitField.Flags.ManageRoles]
+    );
+
+    this.addRoleOption(
+      'role',
+      'The role that belongs to the react role.',
+      true
+    );
+    this.addStringOption(
+      'new-emoji',
+      'The new emoji for the react role.',
+      true
+    );
+  }
+
+  execute = async (interaction: ChatInputCommandInteraction) => {
+    this.expect(interaction.guildId, {
+      message: `Where'd the guild go!?!?`,
+      prop: 'guild id',
+    });
+
+    const role = this.expect(interaction.options.getRole('role'), {
+      message: `Somehow the role is missing! Please try again.`,
+      prop: 'role',
+    });
+    const emoji = this.expect(interaction.options.getString('new-emoji'), {
+      message: 'Somehow the emoji is missing! Please try again.',
+      prop: 'emoji',
+    });
+
+    const parsedEmoji = parseEmoji(emoji);
+
+    if (!parsedEmoji?.id && !parsedEmoji?.name) {
+      return interaction.reply({
+        ephemeral: true,
+        content: `Hey! I had an issue parsing whatever emoji you passed in. Please wait and try again.`,
+      });
+    }
+
+    const emojiContent = parsedEmoji.id ?? parsedEmoji.name;
+    const emojiTag = parsedEmoji?.id
+      ? `<${parsedEmoji.animated ? 'a' : ''}:nn:${parsedEmoji.id}>`
+      : null;
+
+    await UPDATE_REACT_ROLE_EMOJI_ID(role.id, emojiContent);
+    await UPDATE_REACT_ROLE_EMOJI_TAG(role.id, emojiTag);
+
+    this.log.debug(
+      `Updated role[${role.id}] to use emoji[${JSON.stringify(parsedEmoji)} - ${
+        emojiTag ?? parsedEmoji.name
+      }]`,
+      interaction.guildId
+    );
+
+    return interaction.reply({
+      ephemeral: true,
+      content: `:tada: Successfully updated the react role (${emojiTag} - ${RolePing(
+        role.id
+      )} :tada:`,
+    });
+  };
+}

--- a/commands/react/edit.ts
+++ b/commands/react/edit.ts
@@ -4,6 +4,7 @@ import {
   PermissionsBitField,
 } from 'discord.js';
 import {
+  GET_REACT_ROLE_BY_ROLE_ID,
   UPDATE_REACT_ROLE_EMOJI_ID,
   UPDATE_REACT_ROLE_EMOJI_TAG,
 } from '../../src/database/queries/reactRole.query';
@@ -46,6 +47,14 @@ export class ReactEditCommand extends SlashCommand {
       message: 'Somehow the emoji is missing! Please try again.',
       prop: 'emoji',
     });
+
+    const doesReactRoleExist = await GET_REACT_ROLE_BY_ROLE_ID(role.id);
+    if (!doesReactRoleExist) {
+      return interaction.reply({
+        ephemeral: true,
+        content: `Hey! That role doesn't belong to an existing react role.`,
+      });
+    }
 
     const parsedEmoji = parseEmoji(emoji);
 

--- a/commands/react/edit.ts
+++ b/commands/react/edit.ts
@@ -4,6 +4,7 @@ import {
   PermissionsBitField,
 } from 'discord.js';
 import {
+  GET_REACT_ROLE_BY_EMOJI,
   GET_REACT_ROLE_BY_ROLE_ID,
   UPDATE_REACT_ROLE_EMOJI_ID,
   UPDATE_REACT_ROLE_EMOJI_TAG,
@@ -34,10 +35,12 @@ export class ReactEditCommand extends SlashCommand {
   }
 
   execute = async (interaction: ChatInputCommandInteraction) => {
-    this.expect(interaction.guildId, {
-      message: `Where'd the guild go!?!?`,
-      prop: 'guild id',
-    });
+    if (!interaction.guildId) {
+      return interaction.reply({
+        ephemeral: true,
+        content: `Hey! I don't see the guild ID anywhere... that's weird.`,
+      });
+    }
 
     const role = this.expect(interaction.options.getRole('role'), {
       message: `Somehow the role is missing! Please try again.`,
@@ -66,6 +69,21 @@ export class ReactEditCommand extends SlashCommand {
     }
 
     const emojiContent = parsedEmoji.id ?? parsedEmoji.name;
+
+    const doesEmojiBelongToReactRole = await GET_REACT_ROLE_BY_EMOJI(
+      emojiContent,
+      interaction.guildId
+    );
+
+    if (doesEmojiBelongToReactRole) {
+      return interaction.reply({
+        ephemeral: true,
+        content: `Hey! That emoji belongs to a react role (${RolePing(
+          doesEmojiBelongToReactRole.roleId
+        )})`,
+      });
+    }
+
     const emojiTag = parsedEmoji?.id
       ? `<${parsedEmoji.animated ? 'a' : ''}:nn:${parsedEmoji.id}>`
       : null;

--- a/commands/react/index.ts
+++ b/commands/react/index.ts
@@ -1,7 +1,8 @@
 export { ReactChannelCommand } from './channel';
-export { ReactRoleCommand } from './create';
+export { ReactCleanCommand } from './clean';
+export { ReactDeleteCommand } from './remove';
+export { ReactEditCommand } from './edit';
 export { ReactListCommand } from './list';
 export { ReactMessageCommand } from './message';
-export { ReactDeleteCommand } from './remove';
 export { ReactNukeCommand } from './nuke';
-export { ReactCleanCommand } from './clean';
+export { ReactRoleCommand } from './create';

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -149,6 +149,6 @@ export default class RoleBot extends Discord.Client {
     await this.login(this.config.TOKEN);
     this.log.info('Bot connected.');
 
-    buildSlashCommands(false, config.CLIENT_ID !== '493668628361904139');
+    buildSlashCommands(true, config.CLIENT_ID !== '493668628361904139');
   };
 }

--- a/src/database/queries/reactRole.query.ts
+++ b/src/database/queries/reactRole.query.ts
@@ -7,14 +7,14 @@ export const CREATE_REACT_ROLE = async (
   name: string,
   roleId: string,
   emojiId: string,
-  emojiTag: string | undefined,
+  emojiTag: string | null,
   guildId: string,
   type: ReactRoleType
 ) => {
   const reactRole = new ReactRole();
 
   reactRole.emojiId = emojiId;
-  reactRole.emojiTag = emojiTag;
+  reactRole.emojiTag = emojiTag ?? undefined;
   reactRole.roleId = roleId;
   reactRole.guildId = guildId;
   reactRole.name = name;
@@ -77,7 +77,7 @@ export const GET_REACT_ROLES_BY_CATEGORY_ID = async (categoryId: number) => {
 
 export const UPDATE_REACT_ROLE_EMOJI_TAG = async (
   roleId: string,
-  emojiTag: string
+  emojiTag: string | null
 ) => {
   const reactRole = await ReactRole.findOne({
     where: { roleId },
@@ -86,7 +86,23 @@ export const UPDATE_REACT_ROLE_EMOJI_TAG = async (
   if (!reactRole)
     throw Error(`Role[${roleId}] doesn't exist despite having just found it.`);
 
-  reactRole.emojiTag = emojiTag;
+  reactRole.emojiTag = emojiTag ?? undefined;
+
+  return await reactRole.save();
+};
+
+export const UPDATE_REACT_ROLE_EMOJI_ID = async (
+  roleId: string,
+  emojiId: string
+) => {
+  const reactRole = await ReactRole.findOne({
+    where: { roleId },
+  });
+
+  if (!reactRole)
+    throw Error(`Role[${roleId}] doesn't exist despite having just found it.`);
+
+  reactRole.emojiId = emojiId;
 
   return await reactRole.save();
 };


### PR DESCRIPTION
This PR allows users to edit existing react roles emojis so that they don't have to recreate them for a new emoji.
It also introduces `parseEmoji` which is a method I wish knew existed before.