### PR TITLE
feat: guild config react types / button react roles

### DIFF
--- a/commands/category/edit.ts
+++ b/commands/category/edit.ts
@@ -3,11 +3,18 @@ import {
   ChatInputCommandInteraction,
   PermissionsBitField,
 } from 'discord.js';
-import { Category as ICategory, DisplayType } from '../../src/database/entities/category.entity';
+import {
+  Category as ICategory,
+  DisplayType,
+} from '../../src/database/entities/category.entity';
 
 import { Category } from '../../utilities/types/commands';
 import { SlashCommand } from '../slashCommand';
-import { getDisplayCommandValues, handleInteractionReply, parseDisplayString } from '../../utilities/utils';
+import {
+  getDisplayCommandValues,
+  handleInteractionReply,
+  parseDisplayString,
+} from '../../utilities/utils';
 import {
   EDIT_CATEGORY_BY_ID,
   GET_CATEGORY_BY_ID,
@@ -59,7 +66,12 @@ export class EditCategoryCommand extends SlashCommand {
       'new-excluded-role',
       'Change what the required roles are for the category.'
     );
-    this.addStringOption('display-order', 'Change how the category displays the react roles.', false, getDisplayCommandValues());
+    this.addStringOption(
+      'display-order',
+      'Change how the category displays the react roles.',
+      false,
+      getDisplayCommandValues()
+    );
   }
 
   handleAutoComplete = async (interaction: AutocompleteInteraction) => {
@@ -79,16 +91,17 @@ export class EditCategoryCommand extends SlashCommand {
       return this.log.error(`GuildID did not exist on interaction.`);
     }
 
-    const categoryId = this.expect(interaction.options.getString('category'), { message: 'Category appears to be invalid!', prop: `category` });
+    const categoryId = this.expect(interaction.options.getString('category'), {
+      message: 'Category appears to be invalid!',
+      prop: `category`,
+    });
     const newName = interaction.options.getString('new-name');
     const newDesc = interaction.options.getString('new-description');
 
     const mutuallyExclusive =
       interaction.options.getBoolean('mutually-exclusive');
 
-    const removeRoleType = interaction.options.getString(
-      'remove-role-type'
-    );
+    const removeRoleType = interaction.options.getString('remove-role-type');
 
     const newRequiredRoleId =
       interaction.options.getRole('new-required-role')?.id ?? undefined;
@@ -97,7 +110,9 @@ export class EditCategoryCommand extends SlashCommand {
 
     const displayString = interaction.options.getString('display-order');
 
-    const displayOrder = parseDisplayString(displayString as keyof typeof DisplayType);
+    const displayOrder = parseDisplayString(
+      displayString as keyof typeof DisplayType
+    );
 
     if (
       !newName &&
@@ -140,9 +155,15 @@ export class EditCategoryCommand extends SlashCommand {
       name: newName ?? category.name,
       description: newDesc ?? category.description,
       mutuallyExclusive: mutuallyExclusive ?? category.mutuallyExclusive,
-      requiredRoleId: (removeRoleType && removeRoleType === 'required-role') ? null : requiredRoleId,
-      excludedRoleId: (removeRoleType && removeRoleType === 'excluded-role') ? null : excludedRoleId,
-      displayOrder
+      requiredRoleId:
+        removeRoleType && removeRoleType === 'required-role'
+          ? null
+          : requiredRoleId,
+      excludedRoleId:
+        removeRoleType && removeRoleType === 'excluded-role'
+          ? null
+          : excludedRoleId,
+      displayOrder,
     };
 
     EDIT_CATEGORY_BY_ID(category.id, updatedCategory)

--- a/commands/general/config.ts
+++ b/commands/general/config.ts
@@ -1,0 +1,54 @@
+import { ChatInputCommandInteraction, PermissionsBitField } from 'discord.js';
+import { GuildReactType } from '../../src/database/entities/guild.entity';
+import {
+  CREATE_GUILD_CONFIG,
+  EDIT_GUILD_CONFIG,
+  GET_GUILD_CONFIG,
+} from '../../src/database/queries/guild.query';
+import { Category } from '../../utilities/types/commands';
+import {
+  getGuildReactConfigValues,
+  parseGuildReactString,
+} from '../../utilities/utils';
+import { SlashCommand } from '../slashCommand';
+
+export class ConfigCommand extends SlashCommand {
+  constructor() {
+    super(
+      'config',
+      'Edit the servers reaction configurations.',
+      Category.general,
+      [PermissionsBitField.Flags.ManageGuild]
+    );
+
+    this.addStringOption(
+      'react-type',
+      'Change how the bot serves react roles.',
+      false,
+      getGuildReactConfigValues()
+    );
+  }
+
+  execute = async (interaction: ChatInputCommandInteraction) => {
+    if (!interaction.guildId) {
+      return this.log.error(`GuildID did not exist on interaction.`);
+    }
+
+    const { guildId } = interaction;
+
+    // If the config doesn't exist that means we failed to create it on join.
+    let guildConfig = await GET_GUILD_CONFIG(guildId);
+    if (!guildConfig) {
+      guildConfig = CREATE_GUILD_CONFIG(guildId);
+    }
+
+    const reactTypeString = interaction.options.getString('react-type');
+    const reactType = parseGuildReactString(
+      reactTypeString as keyof typeof GuildReactType
+    );
+
+    await EDIT_GUILD_CONFIG(guildId, {
+      reactType,
+    });
+  };
+}

--- a/commands/general/config.ts
+++ b/commands/general/config.ts
@@ -54,7 +54,7 @@ export class ConfigCommand extends SlashCommand {
     const hideEmojis = interaction.options.getBoolean('hide-emojis');
 
     await EDIT_GUILD_CONFIG(guildId, {
-      reactType: reactType ?? guildConfig.reactType,
+      reactType: reactTypeString ? reactType : guildConfig.reactType,
       hideEmojis: hideEmojis ?? guildConfig.hideEmojis,
     });
 

--- a/commands/general/index.ts
+++ b/commands/general/index.ts
@@ -2,3 +2,4 @@ export { HelpCommand } from './help';
 export { InfoCommand } from './info';
 export { AutoJoinCommand } from './join';
 export { TutorialCommand } from './tutorial';
+export { ConfigCommand } from './config';

--- a/commands/react/channel.ts
+++ b/commands/react/channel.ts
@@ -94,7 +94,10 @@ export class ReactChannelCommand extends SlashCommand {
       prop: 'category',
     });
 
-    const roles = await GET_REACT_ROLES_BY_CATEGORY_ID(category.id);
+    const roles = await GET_REACT_ROLES_BY_CATEGORY_ID(
+      category.id,
+      category.displayOrder
+    );
     if (!roles.length) return;
 
     return this.messageChannelAndReact(
@@ -181,7 +184,10 @@ export class ReactChannelCommand extends SlashCommand {
     if (textChannel?.type !== ChannelType.GuildText) return;
 
     for (const category of categories) {
-      const roles = await GET_REACT_ROLES_BY_CATEGORY_ID(category.id, category.displayOrder);
+      const roles = await GET_REACT_ROLES_BY_CATEGORY_ID(
+        category.id,
+        category.displayOrder
+      );
       if (!roles.length) continue;
 
       await this.messageChannelAndReact(

--- a/commands/react/edit.ts
+++ b/commands/react/edit.ts
@@ -92,16 +92,17 @@ export class ReactEditCommand extends SlashCommand {
     await UPDATE_REACT_ROLE_EMOJI_TAG(role.id, emojiTag);
 
     this.log.debug(
-      `Updated role[${role.id}] to use emoji[${JSON.stringify(parsedEmoji)} - ${emojiTag ?? parsedEmoji.name
+      `Updated role[${role.id}] to use emoji[${JSON.stringify(parsedEmoji)} - ${
+        emojiTag ?? parsedEmoji.name
       }]`,
       interaction.guildId
     );
 
     return interaction.reply({
       ephemeral: true,
-      content: `:tada: Successfully updated the react role (${emojiTag ?? parsedEmoji.name} - ${RolePing(
-        role.id
-      )}) :tada:`,
+      content: `:tada: Successfully updated the react role (${
+        emojiTag ?? parsedEmoji.name
+      } - ${RolePing(role.id)}) :tada:`,
     });
   };
 }

--- a/events/guildUpdate.ts
+++ b/events/guildUpdate.ts
@@ -12,7 +12,7 @@ export const guildUpdate = async (
   const color = type === 'Joined' ? Colors.green : Colors.red;
   try {
     if (type === 'Joined') {
-      CREATE_GUILD_CONFIG(guild.id);
+      await CREATE_GUILD_CONFIG(guild.id);
     }
 
     const size = (

--- a/events/guildUpdate.ts
+++ b/events/guildUpdate.ts
@@ -2,6 +2,7 @@ import RoleBot from '../src/bot';
 import { EmbedBuilder, Guild } from 'discord.js';
 import { Colors } from '../src/interfaces';
 import { RoleBotGuildEventsWebhook } from '../utilities/types/globals';
+import { CREATE_GUILD_CONFIG } from '../src/database/queries/guild.query';
 
 export const guildUpdate = async (
   guild: Guild,
@@ -10,6 +11,10 @@ export const guildUpdate = async (
 ) => {
   const color = type === 'Joined' ? Colors.green : Colors.red;
   try {
+    if (type === 'Joined') {
+      CREATE_GUILD_CONFIG(guild.id);
+    }
+
     const size = (
       await client.shard?.fetchClientValues('guilds.cache.size')
     )?.reduce<number>((a, b) => a + Number(b), 0);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -162,6 +162,6 @@ export default class RoleBot extends Discord.Client {
     await this.login(this.config.TOKEN);
     this.log.info('Bot connected.');
 
-    await buildSlashCommands(false, config.CLIENT_ID !== '493668628361904139');
+    await buildSlashCommands(true, config.CLIENT_ID !== '493668628361904139');
   };
 }

--- a/src/database/entities/category.entity.ts
+++ b/src/database/entities/category.entity.ts
@@ -4,10 +4,11 @@ export enum DisplayType {
   alpha = 0,
   reversedAlpha,
   time,
-  reversedTime
+  reversedTime,
 }
 
 export interface ICategory {
+  id: number;
   guildId: string;
   name: string;
   description?: string | null;
@@ -43,7 +44,7 @@ export class Category extends BaseEntity {
   @Column({
     type: 'enum',
     enum: DisplayType,
-    default: DisplayType.alpha
+    default: DisplayType.alpha,
   })
   displayOrder!: DisplayType;
 }

--- a/src/database/entities/guild.entity.ts
+++ b/src/database/entities/guild.entity.ts
@@ -10,6 +10,7 @@ export interface IGuildConfig {
   id: number;
   guildId: string;
   reactType: GuildReactType;
+  hideEmojis: boolean;
 }
 
 @Entity()
@@ -26,4 +27,10 @@ export class GuildConfig extends BaseEntity {
     default: GuildReactType.reaction,
   })
   reactType!: GuildReactType;
+
+  // If reactType is type button, then we can allow the ability to hide emojis in buttons.
+  @Column({
+    default: false,
+  })
+  hideEmojis!: boolean;
 }

--- a/src/database/entities/guild.entity.ts
+++ b/src/database/entities/guild.entity.ts
@@ -1,7 +1,29 @@
-import { BaseEntity, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+export enum GuildReactType {
+  reaction = 0,
+  button,
+  select,
+}
+
+export interface IGuildConfig {
+  id: number;
+  guildId: string;
+  reactType: GuildReactType;
+}
 
 @Entity()
 export class GuildConfig extends BaseEntity {
   @PrimaryGeneratedColumn()
   id!: number;
+
+  @Column()
+  guildId!: string;
+
+  @Column({
+    type: 'enum',
+    enum: GuildReactType,
+    default: GuildReactType.reaction,
+  })
+  reactType!: GuildReactType;
 }

--- a/src/database/entities/reactRole.entity.ts
+++ b/src/database/entities/reactRole.entity.ts
@@ -30,8 +30,8 @@ export class ReactRole extends BaseEntity {
   emojiId!: string;
 
   /* If the emoji is custom this will be the emoji mention. <(a?):name:id> Because emojis can be animated and Discord sucks. */
-  @Column({ nullable: true })
-  emojiTag?: string;
+  @Column({ type: 'character varying', nullable: true })
+  emojiTag!: string | null;
 
   @Column()
   guildId!: string;

--- a/src/database/queries/category.query.ts
+++ b/src/database/queries/category.query.ts
@@ -7,7 +7,10 @@ export const GET_GUILD_CATEGORIES = async (guildId: string) => {
   return await Category.find({ where: { guildId }, order: { name: 'ASC' } });
 };
 
-export const GET_ROLES_BY_CATEGORY_ID = async (categoryId: number, displayType: DisplayType) => {
+export const GET_ROLES_BY_CATEGORY_ID = async (
+  categoryId: number,
+  displayType: DisplayType
+) => {
   const orderProperties = displayOrderQuery(displayType);
 
   return await ReactRole.find({

--- a/src/database/queries/category.query.ts
+++ b/src/database/queries/category.query.ts
@@ -19,7 +19,9 @@ export const GET_ROLES_BY_CATEGORY_ID = async (
   });
 };
 
-export const CREATE_GUILD_CATEGORY = async (category: ICategory) => {
+export const CREATE_GUILD_CATEGORY = async (
+  category: Omit<ICategory, 'id'>
+) => {
   const newCategory = new Category();
 
   newCategory.guildId = category.guildId;

--- a/src/database/queries/guild.query.ts
+++ b/src/database/queries/guild.query.ts
@@ -6,7 +6,11 @@ export const GET_GUILD_CONFIG = (guildId: string) => {
 };
 
 export const CREATE_GUILD_CONFIG = (guildId: string) => {
-  return GuildConfig.create({ guildId });
+  const config = new GuildConfig();
+
+  config.guildId = guildId;
+
+  return config.save();
 };
 
 export const EDIT_GUILD_CONFIG = (

--- a/src/database/queries/guild.query.ts
+++ b/src/database/queries/guild.query.ts
@@ -1,0 +1,17 @@
+import { GuildConfig } from '../entities';
+import { IGuildConfig } from '../entities/guild.entity';
+
+export const GET_GUILD_CONFIG = (guildId: string) => {
+  return GuildConfig.findOne({ where: { guildId } });
+};
+
+export const CREATE_GUILD_CONFIG = (guildId: string) => {
+  return GuildConfig.create({ guildId });
+};
+
+export const EDIT_GUILD_CONFIG = (
+  guildId: string,
+  guildConfig: Partial<IGuildConfig>
+) => {
+  return GuildConfig.update({ guildId }, guildConfig);
+};

--- a/src/database/queries/reactRole.query.ts
+++ b/src/database/queries/reactRole.query.ts
@@ -16,7 +16,7 @@ export const CREATE_REACT_ROLE = async (
   const reactRole = new ReactRole();
 
   reactRole.emojiId = emojiId;
-  reactRole.emojiTag = emojiTag ?? undefined;
+  reactRole.emojiTag = emojiTag;
   reactRole.roleId = roleId;
   reactRole.guildId = guildId;
   reactRole.name = name;
@@ -93,16 +93,7 @@ export const UPDATE_REACT_ROLE_EMOJI_TAG = async (
   roleId: string,
   emojiTag: string | null
 ) => {
-  const reactRole = await ReactRole.findOne({
-    where: { roleId },
-  });
-
-  if (!reactRole)
-    throw Error(`Role[${roleId}] doesn't exist despite having just found it.`);
-
-  reactRole.emojiTag = emojiTag ?? undefined;
-
-  return await reactRole.save();
+  return await ReactRole.update({ roleId }, { emojiTag });
 };
 
 export const UPDATE_REACT_ROLE_EMOJI_ID = async (

--- a/src/database/queries/reactRole.query.ts
+++ b/src/database/queries/reactRole.query.ts
@@ -1,4 +1,4 @@
-import { IsNull } from 'typeorm';
+import { IsNull, Not } from 'typeorm';
 import { displayOrderQuery } from '../../../utilities/utils';
 import { Category, ReactRole } from '../entities';
 import { DisplayType } from '../entities/category.entity';
@@ -64,7 +64,19 @@ export const GET_REACT_ROLE_BY_ROLE_ID = async (roleId: string) => {
   });
 };
 
-export const GET_REACT_ROLES_BY_CATEGORY_ID = async (categoryId: number, displayType?: DisplayType) => {
+export const GET_GUILD_CATEGORY_ROLE_COUNT = async (guildId: string) => {
+  return await ReactRole.count({
+    where: {
+      guildId,
+      categoryId: Not(IsNull()),
+    },
+  });
+};
+
+export const GET_REACT_ROLES_BY_CATEGORY_ID = async (
+  categoryId: number,
+  displayType?: DisplayType
+) => {
   const orderProperties = displayOrderQuery(displayType);
 
   return await ReactRole.find({

--- a/src/services/buttonHandler.ts
+++ b/src/services/buttonHandler.ts
@@ -1,0 +1,133 @@
+import { ButtonInteraction } from 'discord.js';
+import { RolePing } from '../../utilities/utilPings';
+import { GuildReactType } from '../database/entities/guild.entity';
+import { GET_CATEGORY_BY_ID } from '../database/queries/category.query';
+import { GET_GUILD_CONFIG } from '../database/queries/guild.query';
+import { GET_REACT_ROLE_BY_ID } from '../database/queries/reactRole.query';
+import { LogService } from './logService';
+
+export class ButtonHandler {
+  private static log = new LogService('ButtonHandler');
+
+  public static handleButton = async (
+    interaction: ButtonInteraction,
+    args: string[]
+  ) => {
+    if (!interaction.guildId) return;
+
+    const config = await GET_GUILD_CONFIG(interaction.guildId);
+
+    /**
+     * Ignore request if the server react type isn't button related.
+     * This can happen if users swap types and leave old messages up.
+     */
+    if (config?.reactType !== GuildReactType.button) {
+      return interaction.editReply(
+        `Hey! The server doesn't use button roles! The button you clicked must be out of date.`
+      );
+    }
+
+    const [reactRoleId, categoryId] = args;
+
+    if (isNaN(Number(reactRoleId)) || isNaN(Number(categoryId))) {
+      return interaction.editReply(
+        `Hey! Something went wrong with processing that button press! reactRoleId: ${reactRoleId} | categoryId: ${categoryId}`
+      );
+    }
+
+    const reactRole = await GET_REACT_ROLE_BY_ID(Number(reactRoleId));
+    const category = await GET_CATEGORY_BY_ID(Number(categoryId));
+
+    if (!reactRole || !category) {
+      return interaction.editReply(
+        `Hey! I failed to find the react role or category related to this button.`
+      );
+    }
+
+    const member = await interaction.guild?.members
+      .fetch(interaction.user.id)
+      .catch((e) =>
+        this.log.error(
+          `Fetching user[${interaction.user.id}] threw an error.\n${e}`
+        )
+      );
+
+    if (!member) {
+      this.log.debug(
+        `Failed to grab member object from interaction.`,
+        interaction.guildId
+      );
+
+      return interaction.editReply(
+        `Heyo! I had some issues finding _you_ here.`
+      );
+    }
+
+    // If the category limits who can react and the user doesn't have said role ignore request.
+    if (
+      category.requiredRoleId &&
+      !member.roles.cache.has(category.requiredRoleId)
+    ) {
+      // Remove reaction as to not confuse the user that they succeeded.
+      return interaction.editReply(
+        `Hey! You lack the required role to get anything from this category. ${RolePing(
+          category.requiredRoleId
+        )}`
+      );
+    }
+
+    // If the category has an excluded role, and the user has said excluded role, ignore request.
+    if (
+      category.excludedRoleId &&
+      member.roles.cache.has(category.excludedRoleId)
+    ) {
+      return interaction.editReply(
+        `Heyo! You have a role that prevents you from obtaining anything from this category. ${RolePing(
+          category.excludedRoleId
+        )}`
+      );
+    }
+
+    // @TODO - Handle mutually exclusive.
+
+    if (member.roles.cache.has(reactRole.roleId)) {
+      member.roles.remove(reactRole.roleId).catch((e) => {
+        this.log.debug(
+          `Failed to remove role[${reactRole.roleId}] from user[${member.id}]\n${e}`
+        );
+
+        return interaction.editReply(
+          `Hey! I had issues removing the role ${RolePing(
+            reactRole.roleId
+          )}. Do I have manage role permissions?`
+        );
+      });
+
+      return interaction.editReply(
+        `Hey! I remove the role ${RolePing(
+          reactRole.roleId
+        )} from you successfully.`
+      );
+    } else {
+      member.roles.add(reactRole.roleId).catch((e) => {
+        this.log.debug(
+          `Failed to add role[${reactRole.roleId}] to user[${member.id}]\n${e}`
+        );
+
+        return interaction.editReply(
+          `Hey! I had issues adding the role ${RolePing(
+            reactRole.roleId
+          )}. Do I have manage role permissions?`
+        );
+      });
+
+      return interaction.editReply(
+        `Hey! I added the role ${RolePing(
+          reactRole.roleId
+        )} to you successfully.`
+      );
+    }
+
+    return;
+  };
+}

--- a/src/services/embedService.ts
+++ b/src/services/embedService.ts
@@ -84,9 +84,14 @@ export class EmbedService {
     return embed;
   };
 
-  public static reactRolesFormattedString = (reactRoles: ReactRole[]) => {
+  public static reactRolesFormattedString = (
+    reactRoles: ReactRole[],
+    hideEmojis = false
+  ) => {
+    const emoji = (r: ReactRole) => r.emojiTag ?? r.emojiId;
+
     return reactRoles
-      .map((r) => `${r.emojiTag ?? r.emojiId} - ${RolePing(r.roleId)}`)
+      .map((r) => `${hideEmojis ? '' : emoji(r) + ' - '}${RolePing(r.roleId)}`)
       .join('\n');
   };
 
@@ -139,9 +144,13 @@ export class EmbedService {
 
   public static reactRoleEmbed = (
     reactRoles: ReactRole[],
-    category: Category
+    category: Category,
+    hideEmojis = false
   ) => {
-    const reactRolesString = this.reactRolesFormattedString(reactRoles);
+    const reactRolesString = this.reactRolesFormattedString(
+      reactRoles,
+      hideEmojis
+    );
 
     const embed = new EmbedBuilder();
 
@@ -211,15 +220,17 @@ export class EmbedService {
 
   public static guildConfig = async (config: IGuildConfig) => {
     const embed = new EmbedBuilder();
+    const description = `**Hey! If you changed your react type your old messages/buttons will be invalid.\nIf you swap back and haven't deleted those messages then they're still valid. Just make sure the types match for what you want.**`;
 
     embed
       .setColor(Colors.red)
       .setAuthor({ name: 'RoleBot', iconURL: AVATAR_URL })
       .setTitle('Server configuration.')
       .setDescription(
-        `React type: **${
-          GuildReactType[config.reactType]
-        }**\nHide button emojis: **${config.hideEmojis}**`
+        description +
+          `\n\nReact type: **${
+            GuildReactType[config.reactType]
+          }**\nHide button emojis: **${config.hideEmojis}**`
       )
       .setTimestamp(new Date());
 

--- a/src/services/embedService.ts
+++ b/src/services/embedService.ts
@@ -36,7 +36,10 @@ export class EmbedService {
    */
   public static categoryReactRoleEmbed = async (category: Category) => {
     const embed = new EmbedBuilder();
-    const categoryRoles = await GET_REACT_ROLES_BY_CATEGORY_ID(category.id, category.displayOrder);
+    const categoryRoles = await GET_REACT_ROLES_BY_CATEGORY_ID(
+      category.id,
+      category.displayOrder
+    );
 
     const reactRoles = categoryRoles.length
       ? this.reactRolesFormattedString(categoryRoles)
@@ -50,17 +53,24 @@ export class EmbedService {
     let displayOrder = 'Alphabetical';
 
     switch (category.displayOrder) {
-      case DisplayType.reversedAlpha: displayOrder = 'Reversed alphabetical'; break;
-      case DisplayType.time: displayOrder = 'Insertion order'; break;
-      case DisplayType.reversedTime: displayOrder = 'Reversed insertion'; break;
+      case DisplayType.reversedAlpha:
+        displayOrder = 'Reversed alphabetical';
+        break;
+      case DisplayType.time:
+        displayOrder = 'Insertion order';
+        break;
+      case DisplayType.reversedTime:
+        displayOrder = 'Reversed insertion';
+        break;
     }
 
     embed
       .setTitle(category.name)
       .setDescription(
-        `Required Role: ${category.requiredRoleId ? RolePing(category.requiredRoleId) : 'None!'
-        }\n\nReact role display order: **${displayOrder
-        }**\n\nMutually exclusive: **${category.mutuallyExclusive
+        `Required Role: ${
+          category.requiredRoleId ? RolePing(category.requiredRoleId) : 'None!'
+        }\n\nReact role display order: **${displayOrder}**\n\nMutually exclusive: **${
+          category.mutuallyExclusive
         }**\n\nDesc: **${escapeMarkdown(desc)}**\n\n${reactRoles}`
       )
       .setColor(COLOR.DEFAULT);
@@ -87,14 +97,14 @@ export class EmbedService {
 
     const inCategory = rolesInCategory.length
       ? `**In a category:**\n${this.reactRolesFormattedString(
-        rolesInCategory
-      )}\n`
+          rolesInCategory
+        )}\n`
       : '';
 
     const notInCategory = rolesNotInCategory.length
       ? `**Not in a category:**\n${this.reactRolesFormattedString(
-        rolesNotInCategory
-      )}`
+          rolesNotInCategory
+        )}`
       : '';
 
     embed
@@ -165,9 +175,9 @@ export class EmbedService {
       .setColor(Colors.green)
       .setDescription(
         `These roles are given to users as they join your server.\nCurrently the max limit a server can have is 5.\n\n` +
-        (roleIds.length > 0
-          ? roleIds.map((r) => RolePing(r)).join('\n')
-          : `There are none! Go add some with the \`/auto-join add @Role\` command.`)
+          (roleIds.length > 0
+            ? roleIds.map((r) => RolePing(r)).join('\n')
+            : `There are none! Go add some with the \`/auto-join add @Role\` command.`)
       )
       .setTimestamp(new Date());
 

--- a/src/services/embedService.ts
+++ b/src/services/embedService.ts
@@ -10,6 +10,10 @@ import { RolePing } from '../../utilities/utilPings';
 import { Category as CommandCategory } from '../../utilities/types/commands';
 import tutorialJson from '../../utilities/json/tutorial.json';
 import commands from '../../utilities/json/commands.json';
+import {
+  GuildReactType,
+  IGuildConfig,
+} from '../database/entities/guild.entity';
 
 export class EmbedService {
   /**
@@ -200,6 +204,23 @@ export class EmbedService {
       .setAuthor({ name: 'RoleBot', iconURL: AVATAR_URL })
       .setTitle(`Encountered an error`)
       .setDescription(codeBlock('diff', content))
+      .setTimestamp(new Date());
+
+    return embed;
+  };
+
+  public static guildConfig = async (config: IGuildConfig) => {
+    const embed = new EmbedBuilder();
+
+    embed
+      .setColor(Colors.red)
+      .setAuthor({ name: 'RoleBot', iconURL: AVATAR_URL })
+      .setTitle('Server configuration.')
+      .setDescription(
+        `React type: **${
+          GuildReactType[config.reactType]
+        }**\nHide button emojis: **${config.hideEmojis}**`
+      )
       .setTimestamp(new Date());
 
     return embed;

--- a/utilities/utilButtons.ts
+++ b/utilities/utilButtons.ts
@@ -1,0 +1,27 @@
+import { ActionRowBuilder } from '@discordjs/builders';
+import { ButtonBuilder, ButtonStyle } from 'discord.js';
+import { ReactRole } from '../src/database/entities';
+import { spliceIntoChunks } from './utils';
+
+export const reactRoleButtons = (
+  reactRoles: ReactRole[],
+  hideEmojis: boolean
+) => {
+  const customId = (r: ReactRole) => `react-button_${r.id}-${r.categoryId}`;
+  const buildButton = (r: ReactRole) => {
+    const button = new ButtonBuilder()
+      .setCustomId(customId(r))
+      .setLabel(r.name)
+      .setStyle(ButtonStyle.Secondary);
+
+    if (hideEmojis) {
+      return button;
+    } else {
+      return button.setEmoji(r.emojiId);
+    }
+  };
+
+  return spliceIntoChunks(reactRoles, 5).map((roles) =>
+    new ActionRowBuilder<ButtonBuilder>().addComponents(roles.map(buildButton))
+  );
+};

--- a/utilities/utils.ts
+++ b/utilities/utils.ts
@@ -11,6 +11,7 @@ import {
 } from 'discord.js';
 import { ReactRole } from '../src/database/entities';
 import { DisplayType } from '../src/database/entities/category.entity';
+import { GuildReactType } from '../src/database/entities/guild.entity';
 import {
   GET_CATEGORY_BY_ID,
   GET_ROLES_BY_CATEGORY_ID,
@@ -48,7 +49,8 @@ export const reactToMessage = async (
       });
     } catch (e) {
       log.debug(
-        `Failed to react to message[${message.id}] with emoji[${role.emojiTag ?? role.emojiId
+        `Failed to react to message[${message.id}] with emoji[${
+          role.emojiTag ?? role.emojiId
         }] in guild[${guildId}]\n${e}`
       );
 
@@ -216,12 +218,12 @@ export async function isValidRolePosition(
   return clientUser.roles.highest.position > role.position;
 }
 
-interface ICommandStringOptions {
+interface IDisplayOptions {
   name: string;
   value: keyof typeof DisplayType;
 }
 
-export function getDisplayCommandValues(): ICommandStringOptions[] {
+export function getDisplayCommandValues(): IDisplayOptions[] {
   return [
     { name: 'Alphabetical', value: 'alpha' },
     { name: 'Reverse alphabetical', value: 'reversedAlpha' },
@@ -240,10 +242,33 @@ export function displayOrderQuery(display?: DisplayType): {
   [k: string]: 'ASC' | 'DESC';
 } {
   switch (display) {
-    case DisplayType.alpha: return { name: 'ASC' };
-    case DisplayType.reversedAlpha: return { name: 'DESC' };
-    case DisplayType.time: return { categoryAddDate: 'ASC' };
-    case DisplayType.reversedTime: return { categoryAddDate: 'DESC' };
-    default: return { name: 'ASC' };
+    case DisplayType.alpha:
+      return { name: 'ASC' };
+    case DisplayType.reversedAlpha:
+      return { name: 'DESC' };
+    case DisplayType.time:
+      return { categoryAddDate: 'ASC' };
+    case DisplayType.reversedTime:
+      return { categoryAddDate: 'DESC' };
+    default:
+      return { name: 'ASC' };
   }
+}
+
+interface IConfigOptions {
+  name: string;
+  value: keyof typeof GuildReactType;
+}
+
+export function getGuildReactConfigValues(): IConfigOptions[] {
+  return [
+    { name: 'Reaction', value: 'reaction' },
+    { name: 'Button', value: 'button' },
+  ];
+}
+
+export function parseGuildReactString(
+  reactType: keyof typeof GuildReactType | null
+): GuildReactType {
+  return GuildReactType[reactType ?? 'reaction'];
 }


### PR DESCRIPTION
Allow servers to configure what type of react system they use and if they are of button type ability to hide emojis.

![image](https://user-images.githubusercontent.com/14780600/201826457-ac8870c9-3a20-4937-89da-035733ce0775.png)


TODO
* Mutually exclusive roles for button handler
* Update tutorial to show new types
* When changing guild config show images of potential react embeds